### PR TITLE
Find and replace Facebook -> LinkedIn

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,45 @@
-# Facebook Container
+# LinkedIn Container
 
-**Prevent Facebook from tracking your visits to other websites**
+**Prevent LinkedIn from tracking your visits to other websites**
 
-Facebook Container is an add-on you can install on Firefox to prevent Facebook from tracking your activity on other websites, so you can continue to use Facebook while protecting your privacy.
+LinkedIn Container is an add-on you can install on Firefox to prevent LinkedIn from tracking your activity on other websites, so you can continue to use LinkedIn while protecting your privacy.
 
 **Note:** To learn more about Containers in general, see [Firefox Multi-Account Containers](https://support.mozilla.org/kb/containers).
 
-## How does Facebook Container work?
+## How does LinkedIn Container work?
 
-The Add-on keeps Facebook in a separate Container to prevent it from following your activity on other websites. When you first install the add-on, it signs you out of Facebook and deletes the cookies that Facebook uses to track you on other websites. 
+The Add-on keeps LinkedIn in a separate Container to prevent it from following your activity on other websites. When you first install the add-on, it signs you out of LinkedIn and deletes the cookies that LinkedIn uses to track you on other websites. 
 
-Every time you visit Facebook, it will open in its own container, separate from other websites you visit.  You can login to Facebook within its container.  When browsing outside the container, Facebook won’t be able to easily collect your browsing data and connect it to your Facebook identity.
+Every time you visit LinkedIn, it will open in its own container, separate from other websites you visit.  You can login to LinkedIn within its container.  When browsing outside the container, LinkedIn won’t be able to easily collect your browsing data and connect it to your LinkedIn identity.
 
-## How do I enable Facebook Container?
+## How do I enable LinkedIn Container?
 
 We’ve made it easy to take steps to protect your privacy so you can go on with your day.
 
-1. [Install Facebook Container](https://addons.mozilla.org/firefox/addon/facebook-container/). This will log you out of Facebook and delete the cookies it’s been using to track you.
-2. Open Facebook and use it like you normally would.  Firefox will automatically switch to the Facebook Container tab for you.
-3. If you click on a link to a page outside of Facebook or type in another website in the address bar, Firefox will load them outside of the Facebook Container
+1. [Install LinkedIn Container](https://addons.mozilla.org/firefox/addon/LinkedIn-container/). This will log you out of LinkedIn and delete the cookies it’s been using to track you.
+2. Open LinkedIn and use it like you normally would.  Firefox will automatically switch to the LinkedIn Container tab for you.
+3. If you click on a link to a page outside of LinkedIn or type in another website in the address bar, Firefox will load them outside of the LinkedIn Container
 
-## How does this affect Facebook’s features?
+## How does this affect LinkedIn’s features?
 
-Facebook Containers prevents Facebook from linking your activity on other websites to your Facebook identity. Therefore, the following will not work:
+LinkedIn Containers prevents LinkedIn from linking your activity on other websites to your LinkedIn identity. Therefore, the following will not work:
 
-### “Like” buttons and embedded Facebook comments on other websites.
+### “Like” buttons and embedded LinkedIn comments on other websites.
 
-Because you are logged into Facebook only in the Container, “Like” buttons and embedded Facebook comments on other websites will not work.
+Because you are logged into LinkedIn only in the Container, “Like” buttons and embedded LinkedIn comments on other websites will not work.
 
-### Logging in or creating accounts on other websites using Facebook
+### Logging in or creating accounts on other websites using LinkedIn
 
-Websites that allow you to create an account or log in using Facebook will generally not work properly.
+Websites that allow you to create an account or log in using LinkedIn will generally not work properly.
 
-## Will this protect me from Facebook completely?
+## Will this protect me from LinkedIn completely?
 
-This add-on does not prevent Facebook from mishandling the data it already has or permitted others to obtain about you. Facebook still will have access to everything that you do while you are on facebook.com or on the Facebook app, including your Facebook comments, photo uploads, likes, and any data you share with Facebook connected apps, etc.  
+This add-on does not prevent LinkedIn from mishandling the data it already has or permitted others to obtain about you. LinkedIn still will have access to everything that you do while you are on LinkedIn.com or on the LinkedIn app, including your LinkedIn comments, photo uploads, likes, and any data you share with LinkedIn connected apps, etc.  
 
-Other ad networks may try to link your Facebook activities with your regular browsing. In addition to this add-on, there are other things you can do to maximize your protection, including changing your Facebook settings, using Private Browsing and Tracking Protection, blocking third-party cookies, and/or using [Firefox Multi-Account Containers](https://addons.mozilla.org/firefox/addon/multi-account-containers/ ) extension to further limit tracking.
+Other ad networks may try to link your LinkedIn activities with your regular browsing. In addition to this add-on, there are other things you can do to maximize your protection, including changing your LinkedIn settings, using Private Browsing and Tracking Protection, blocking third-party cookies, and/or using [Firefox Multi-Account Containers](https://addons.mozilla.org/firefox/addon/multi-account-containers/ ) extension to further limit tracking.
 
 ## How do I use Containers for other websites?
 
-Good news! Containers aren’t just for Facebook. You can use Containers to prevent websites from linking your identities across the Web by installing [Firefox Multi-Account Containers](https://addons.mozilla.org/firefox/addon/multi-account-containers/).
+Good news! Containers aren’t just for LinkedIn. You can use Containers to prevent websites from linking your identities across the Web by installing [Firefox Multi-Account Containers](https://addons.mozilla.org/firefox/addon/multi-account-containers/).
 
 To learn more about how Mult-Account Containers work, see our support page at [Firefox Multi-Account Containers](https://addons.mozilla.org/firefox/addon/multi-account-containers/).


### PR DESCRIPTION
Also can you open up the issues on this repo? I have an issue in Firefox on Manjaro Linux where when I open LinkedIn in a new tab, e.g. duplicating a tab and then going to LinkedIn via the URL bar, and the new tab is moved to the end. Which is not what I want.